### PR TITLE
Fix format reclassification and improve include drop handling

### DIFF
--- a/codexify_project/codexify/clients/gui/main_window.py
+++ b/codexify_project/codexify/clients/gui/main_window.py
@@ -557,8 +557,25 @@ class MainWindow(BaseTk):
             except Exception:
                 pass
             if target == 'include':
-                # apply same policy as manual move
+                from pathlib import Path
+
+                # apply same policy as manual move for currently selected entries
                 self._move_selected(self.include_list, 'include')  # reuse path
+
+                active = set(self.engine.state.active_formats or [])
+                new_exts = {Path(p).suffix.lower() for p in collected if Path(p).suffix}
+                missing = sorted([ext for ext in new_exts if ext not in active])
+                if missing:
+                    missing_text = ', '.join(missing)
+                    ans = messagebox.askyesno(
+                        "Add formats?",
+                        f"Selected files contain new types: {missing_text}.\nAdd these formats and include ALL files of these types?"
+                    )
+                    if ans:
+                        active.update(missing)
+                        self.engine.set_active_formats(active)
+                        pool = set(self.engine.state.include_files) | set(self.engine.state.other_files) | collected
+                        collected |= {p for p in pool if Path(p).suffix.lower() in missing}
                 # fallback include only collected if selection not present
                 self.engine.move_files(collected, 'include')
             else:

--- a/codexify_project/codexify/engine.py
+++ b/codexify_project/codexify/engine.py
@@ -223,6 +223,9 @@ class CodexifyEngine:
         if not files:
             return
         self.log.debug("remove_files | count=%d", len(files))
+        from_include = set(files) & set(self.state.include_files)
+        from_other = set(files) & set(self.state.other_files)
+
         self.state.include_files -= files
         self.state.other_files -= files
         self.state.ignored_files.update(files)
@@ -233,8 +236,8 @@ class CodexifyEngine:
         self._undo_stack.append({
             'type': 'remove',
             'files': set(files),
-            'from_include': set(files) & self.state.include_files,
-            'from_other': set(files) & self.state.other_files,
+            'from_include': from_include,
+            'from_other': from_other,
         })
         self._redo_stack.clear()
         self.events.post(FILES_UPDATED)
@@ -460,7 +463,7 @@ class CodexifyEngine:
         Internal method to classify all_discovered_files into
         include_files, other_files, and ignored_files based on active_formats.
         """
-        if not self.state.all_discovered_files:
+        if not (self.state.all_discovered_files or self.state.include_files or self.state.other_files):
             return
         
         self.log.debug("classify | discovered=%d", len(self.state.all_discovered_files))

--- a/codexify_project/tests/test_engine.py
+++ b/codexify_project/tests/test_engine.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from codexify.engine import CodexifyEngine  # noqa: E402
+
+
+def test_classify_manual_files_without_discovery(tmp_path):
+    engine = CodexifyEngine()
+
+    swift_file = tmp_path / "Foo.swift"
+    text_file = tmp_path / "notes.txt"
+    swift_file.write_text("class Foo {}", encoding="utf-8")
+    text_file.write_text("notes", encoding="utf-8")
+
+    engine.state.all_discovered_files = set()
+    engine.state.include_files = set()
+    engine.state.other_files = {str(swift_file), str(text_file)}
+
+    engine.set_active_formats({".swift"})
+
+    assert str(swift_file) in engine.state.include_files
+    assert str(text_file) in engine.state.other_files
+
+
+def test_remove_files_records_original_buckets(tmp_path):
+    engine = CodexifyEngine()
+
+    inc_file = tmp_path / "Sample.swift"
+    oth_file = tmp_path / "Example.txt"
+    inc_file.write_text("", encoding="utf-8")
+    oth_file.write_text("", encoding="utf-8")
+
+    engine.state.include_files = {str(inc_file)}
+    engine.state.other_files = {str(oth_file)}
+
+    engine.remove_files({str(inc_file), str(oth_file)})
+
+    action = engine._undo_stack[-1]
+
+    assert action["from_include"] == {str(inc_file)}
+    assert action["from_other"] == {str(oth_file)}


### PR DESCRIPTION
## Summary
- ensure engine reclassifies manually added files even when no project scan is loaded and track original buckets when removing files for undo support
- update include drop handling to prompt for new formats and sync active formats when accepting external files
- add regression tests covering manual classification and remove history bookkeeping

## Testing
- pytest tests/test_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68e651bc2764832eb8375a8be919ec5c